### PR TITLE
feat: added support prefetch of mpeg-dash segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ docs/api/
 coverage/
 .DS_Store
 .vscode
+/.idea/codeStyles/codeStyleConfig.xml
+/.idea/modules.xml
+/.idea/codeStyles/Project.xml
+/.idea/inspectionProfiles/Project_Default.xml
+/.idea/shaka-player.iml
+/.idea/vcs.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,7 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+
+.idea

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -799,7 +799,8 @@ shaka.extern.ManifestConfiguration;
  *   forceHTTPS: boolean,
  *   preferNativeHls: boolean,
  *   updateIntervalSeconds: number,
- *   dispatchAllEmsgBoxes: boolean
+ *   dispatchAllEmsgBoxes: boolean,
+ *   prefetchLimit: number
  * }}
  *
  * @description
@@ -910,6 +911,8 @@ shaka.extern.ManifestConfiguration;
  *   The minimum number of seconds to see if the manifest has changes.
  * @property {boolean} dispatchAllEmsgBoxes
  *   If true, all emsg boxes are parsed and dispatched.
+ * @property {number} prefetchLimit
+ *   The maximum number of segments to prefetch.
  *
  * @exportDoc
  */

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -109,6 +109,14 @@ shaka.media.StreamingEngine = class {
 
     /** @private {!shaka.util.Destroyer} */
     this.destroyer_ = new shaka.util.Destroyer(() => this.doDestroy_());
+
+    /**
+     * Maps a reference to op
+     *
+     * @private {!Map.<shaka.media.AnySegmentReference,
+                         !shaka.net.NetworkingEngine.PendingRequest>}
+     */
+    this.prefetchMap_ = new Map();
   }
 
   /** @override */
@@ -808,6 +816,7 @@ shaka.media.StreamingEngine = class {
       recovering: false,
       hasError: false,
       operation: null,
+      prefetchPosTime: 0,
     });
   }
 
@@ -1060,6 +1069,8 @@ shaka.media.StreamingEngine = class {
       shaka.log.v2(logPrefix, 'waiting for other streams to buffer');
       return this.config_.updateIntervalSeconds;
     }
+
+    this.prefetch_(mediaState, reference);
 
     const p = this.fetchAndAppend_(mediaState, presentationTime, reference);
     p.catch(() => {});  // TODO(#1993): Handle asynchronous errors.
@@ -1767,6 +1778,32 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   async fetch_(mediaState, reference, streamDataCallback) {
+    shaka.log.v2('fetching: reference=', reference);
+
+    let op = null;
+    if (this.prefetchMap_.has(reference)) {
+      op = this.prefetchMap_.get(reference);
+      this.prefetchMap_.delete(reference);
+    } else {
+      op = this.fireRequest_(reference, mediaState, streamDataCallback);
+    }
+
+    mediaState.operation = op;
+    const response = await op.promise;
+    mediaState.operation = null;
+    return response.data;
+  }
+
+  /**
+   * Fire the request.
+   * @param {!shaka.media.StreamingEngine.MediaState_=} mediaState
+   * @param {(!shaka.media.InitSegmentReference|!shaka.media.SegmentReference)}
+   *   reference
+   * @param {?function(BufferSource):!Promise=} streamDataCallback
+   *
+   * @private
+   */
+  fireRequest_(reference, mediaState, streamDataCallback) {
     const requestType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
 
     const request = shaka.util.Networking.createSegmentRequest(
@@ -1777,25 +1814,49 @@ shaka.media.StreamingEngine = class {
         streamDataCallback);
 
     shaka.log.v2('fetching: reference=', reference);
+    if (mediaState) {
+      const stream = mediaState.stream;
+      this.playerInterface_.modifySegmentRequest(
+          request,
+          {
+            type: stream.type,
+            init: reference instanceof shaka.media.InitSegmentReference,
+            duration: reference.endTime - reference.startTime,
+            mimeType: stream.mimeType,
+            codecs: stream.codecs,
+            bandwidth: stream.bandwidth,
+          },
+      );
+    }
+    return this.playerInterface_.netEngine.request(requestType, request);
+  }
 
-    const stream = mediaState.stream;
-    this.playerInterface_.modifySegmentRequest(
-        request,
-        {
-          type: stream.type,
-          init: reference instanceof shaka.media.InitSegmentReference,
-          duration: reference.endTime - reference.startTime,
-          mimeType: stream.mimeType,
-          codecs: stream.codecs,
-          bandwidth: stream.bandwidth,
-        },
-    );
-
-    const op = this.playerInterface_.netEngine.request(requestType, request);
-    mediaState.operation = op;
-    const response = await op.promise;
-    mediaState.operation = null;
-    return response.data;
+  /**
+   * Fetches the given segment.
+   *
+   * @param {!shaka.media.StreamingEngine.MediaState_} mediaState
+   * @param
+   *  {(!shaka.media.InitSegmentReference|!shaka.media.SegmentReference)}
+   *   startReference
+   *
+   * @private
+   */
+  prefetch_(mediaState, startReference) {
+    const currTime = mediaState.segmentIterator.current().startTime;
+    mediaState.segmentIterator.seek(
+        Math.max(currTime, mediaState.prefetchPosTime));
+    let reference = startReference;
+    while (this.prefetchMap_.size < this.config_.prefetchLimit &&
+    reference != null) {
+      if (!this.prefetchMap_.has(reference)) {
+        const op = this.fireRequest_(reference);
+        this.prefetchMap_.set(reference, op);
+      }
+      mediaState.prefetchPosTime =
+        mediaState.segmentIterator.current().startTime;
+      reference = mediaState.segmentIterator.next().value;
+    }
+    mediaState.segmentIterator.seek(currTime);
   }
 
 
@@ -2010,7 +2071,8 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   clearingBuffer: boolean,
  *   recovering: boolean,
  *   hasError: boolean,
- *   operation: shaka.net.NetworkingEngine.PendingRequest
+ *   operation: shaka.net.NetworkingEngine.PendingRequest,
+ *   prefetchPosTime: number
  * }}
  *
  * @description
@@ -2024,6 +2086,8 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   The current Stream.
  * @property {shaka.media.SegmentIndexIterator} segmentIterator
  *   An iterator through the segments of |stream|.
+ * @property {number} prefetchPosTime
+ *   Last prefetched time through the segments of |stream|.
  * @property {shaka.media.SegmentReference} lastSegmentReference
  *   The SegmentReference of the last segment that was appended.
  * @property {shaka.media.InitSegmentReference} lastInitSegmentReference
@@ -2060,6 +2124,8 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   updating.
  * @property {shaka.net.NetworkingEngine.PendingRequest} operation
  *   Operation with the number of bytes to be downloaded.
+ * @property {number} prefetchPosTime
+ *   Last prefetched time through the segments of |stream|.
  */
 shaka.media.StreamingEngine.MediaState_;
 

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -166,6 +166,7 @@ shaka.util.PlayerConfiguration = class {
       preferNativeHls: false,
       updateIntervalSeconds: 1,
       dispatchAllEmsgBoxes: false,
+      prefetchLimit: 10,
     };
 
     // Some browsers will stop earlier than others before a gap (e.g., Edge

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "python build/checkversion.py && python build/all.py --force"
+    "prepublishOnly": "python build/all.py --force"
   },
   "dependencies": {
     "eme-encryption-scheme-polyfill": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -1,15 +1,9 @@
 {
   "name": "shaka-player",
   "description": "DASH/EME video player library",
-  "version": "3.3.0-pre",
-  "homepage": "https://github.com/google/shaka-player",
-  "author": "Google",
-  "maintainers": [
-    {
-      "name": "Joey Parrish",
-      "email": "joeyparrish@google.com"
-    }
-  ],
+  "version": "1.0",
+  "homepage": "https://github.com/drishtilabs/shaka-player",
+  "author": "Drishti",
   "devDependencies": {
     "@chiragrupani/karma-chromium-edge-launcher": "^2.1.0",
     "@teppeis/clutz": "^1.0.29-4c95e12.v20190929",
@@ -64,10 +58,10 @@
   "main": "dist/shaka-player.compiled.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/shaka-player.git"
+    "url": "https://github.com/drishtilabs/shaka-player.git"
   },
   "bugs": {
-    "url": "https://github.com/google/shaka-player/issues"
+    "url": "https://github.com/drishtilabs/shaka-player/issues"
   },
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
## Description
This diff adds the ability to download segments listed in a
mpeg-dash manifest in parallel. Before this diff, the segments
would be downloaded serially. This despite knowing the list of
segments to be downloaded apriori. This diff changes that allows
shaka-player to prefetch segment downloads.

The exact level of parallelism, or the exact number of segments
to be prefetched is controlled via a configuration "prefetchLimit".
When set to zero, it defaults back to older behaviour. When set
to a positive number, shaka-player would prefetch only those many
segments in parallel and then wait until some of the ongoing
downloads finish before issuing more prefetch requests.

There are some strange observations w.r.t. behaviour with range
requests, pre-flight OPTIONS request and chrome. In many cases,
every segment request is proceeding by an OPTIONS request. With
the browser's cache disabled this often leads to multiple identical
OPTIONS request. When the cache is enabled, that causes an undesirable
behaviour with chrome. Chrome's cache has a writer lock and it blocks
any subsequent request that has the same URL as the one being
currently downloaded. This for range requests often defeats the
purpose of the diff as it leads to serialization of all range
requests for the same segment (same URL). Thankfully, firefox
does not see this issue.

ref:  [https://github.com/sabyasachiroy/shaka-player/commit/fc295ba00919b88de3555f0aa84e849e7cc6f913](https://github.com/sabyasachiroy/shaka-player/commit/fc295ba00919b88de3555f0aa84e849e7cc6f913)